### PR TITLE
fix struct blocks

### DIFF
--- a/src/compile-time.reflection.jl
+++ b/src/compile-time.reflection.jl
@@ -227,6 +227,11 @@ function parse_class_body!(ln::LineNumberNode, self::TypeDef, body; preprocess::
             continue
         end
 
+        if Meta.isexpr(x, :block)
+            parse_class_body!(ln, self, x.args; preprocess = preprocess)
+            continue
+        end
+
         if (field_info = parse_field_def(ln, x, fallback = nothing)) isa FieldInfo
             push!(self.fields, field_info)
             continue

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -303,21 +303,25 @@ module structdef
         end
     end
 
+    macro gen()
+        quote
+            a :: Int
+            b :: Nothing
+        end |> esc
+    end
+    @oodef struct TestBlockType
+        @gen
+        begin
+            c :: Bool
+            d :: Char
+        end
+    end
     @testset "blocks in struct" begin
-        macro gen()
-            quote
-                a :: Int
-                b :: Nothing
-            end |> esc
-        end
-        @oodef struct TestBlockType
-            @gen
-            begin
-                c :: Bool
-                d :: Char
-            end
-        end
-        TestBlockType(1, nothing, true, 'a')
+        obj = TestBlockType(1, nothing, true, 'a')
+        @test obj.a == 1
+        @test obj.b === nothing
+        @test obj.c === true
+        @test obj.d == 'a'
     end
 
     z = "2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -303,6 +303,23 @@ module structdef
         end
     end
 
+    @testset "blocks in struct" begin
+        macro gen()
+            quote
+                a :: Int
+                b :: Nothing
+            end |> esc
+        end
+        @oodef struct TestBlockType
+            @gen
+            begin
+                c :: Bool
+                d :: Char
+            end
+        end
+        TestBlockType(1, nothing, true, 'a')
+    end
+
     z = "2"
     some_ref_val = Ref(2)
     @oodef struct TestDefaultFieldsImmutable


### PR DESCRIPTION
Fix corner cases, where class declarations are generated by a macro (hence a block of expressions).

This is valid julia syntax, so it should be allowed (see the added test).

Without this PR, the added test fails with:
```julia
ERROR: LoadError: LoadError: unrecognised statement in TestBlockType definition: begin
    #= REPL[4]:3 =#
    a::Int
    #= REPL[4]:4 =#
    b::Nothing
end
```