### PR TITLE
allow documenting a struct

### DIFF
--- a/src/compile-time.buildclass.jl
+++ b/src/compile-time.buildclass.jl
@@ -341,15 +341,15 @@ function codegen(cur_line :: LineNumberNode, cur_mod::Module, type_def::TypeDef)
     outer_block = [
         [
             :(struct $traithead end),
-            Expr(:struct,
+            :(Base.@__doc__ $(Expr(:struct,
                 type_def.isMutable,
                 :($defhead <: $_merge_shape_types($traithead, $(to_expr.(type_def.bases)...))),
-                Expr(:block, struct_block...)),
-            :($ObjectOriented.CompileTime._shape_type(t::$Type{<:$typename}) = $supertype(t)),
+                Expr(:block, struct_block...)))),
+            :(Base.@__doc__ $ObjectOriented.CompileTime._shape_type(t::$Type{<:$typename}) = $supertype(t)),
 
         ];
         [
-            :($ObjectOriented.RunTime.default_initializers(t::$Type{<:$typename}) = $expr_default_initializers)
+            :(Base.@__doc__ $ObjectOriented.RunTime.default_initializers(t::$Type{<:$typename}) = $expr_default_initializers)
         ];
         outer_block
     ]

--- a/src/compile-time.jl
+++ b/src/compile-time.jl
@@ -19,7 +19,9 @@ include("compile-time.static_dispatch.jl")
 macro oodef(ex)
     preprocess(x) = Base.macroexpand(__module__, x)
     type_def = parse_class(__source__, ex, preprocess=preprocess)
-    esc(canonicalize_where(codegen(__source__, __module__, type_def)))
+    quote
+        Base.@__doc__ $(canonicalize_where(codegen(__source__, __module__, type_def)))
+    end |> esc
 end
 
 end # module

--- a/src/compile-time.reflection.jl
+++ b/src/compile-time.reflection.jl
@@ -222,7 +222,7 @@ function parse_class_body!(ln::LineNumberNode, self::TypeDef, body; preprocess::
             x = preprocess(x)
         end
 
-        if x isa LineNumberNode
+        if x isa LineNumberNode || x isa String
             ln = x
             continue
         end
@@ -247,7 +247,7 @@ function parse_class_body!(ln::LineNumberNode, self::TypeDef, body; preprocess::
             push!(self.methods, func_info)
             continue
         end
-        throw(create_exception(ln, "unrecognised statement in $(self.name) definition: $(x)"))
+        throw(create_exception(ln, "unrecognised statement in $(self.name) definition: $x"))
 
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -348,6 +348,25 @@ module structdef
         @test some_ref_val[] == 5
         @test x.b == "sada"
     end
+
+    """
+    Documented struct fancy docstring
+    """
+    @oodef struct DocumentedStruct
+        a :: Int
+        """
+        Constructor docstring
+        """
+        function new(x)
+            @mk a = 2x
+        end
+    end
+
+    @testset "documented struct" begin
+        x = DocumentedStruct(123)
+        @test occursin("Documented struct fancy docstring", string(@doc(DocumentedStruct)))
+        @test x.a == 246
+    end
 end
 
 include("example.jl")


### PR DESCRIPTION
Fix the following issues with docstrings:

```julia
using ObjectOriented

"""
Documented struct fancy docstring
"""
@oodef struct DocumentedStruct
    a :: Int
    """
    Constructor docstring
    """
    function new(x)
        @mk a = 2x
    end
end

ERROR: LoadError: unrecognised statement in DocumentedStruct definition: Constructor docstring

# and

ERROR: LoadError: cannot document the following expression:

'@oodef' not documentable. See 'Base.@__doc__' docs for details.
```

